### PR TITLE
✨ Add metadata only to template language

### DIFF
--- a/src/extension/getChangesForArbFiles.ts
+++ b/src/extension/getChangesForArbFiles.ts
@@ -17,10 +17,14 @@ export async function getChangesForArbFiles(
   parameters: EditFilesParameters
 ): Promise<vscode.WorkspaceEdit> {
   const projectName = getProjectName(parameters.uri);
-  const files = await getArbFiles(projectName);
+  const [files, templateFile] = await getArbFiles(projectName);
   if (files.length === 0) {
     vscode.window.showErrorMessage(`No arb files found.`);
     throw new Error(`No arb files found.`);
+  }
+  if (!templateFile) {
+    vscode.window.showErrorMessage(`No template arb file found.`);
+    throw new Error(`No template arb file found.`);
   }
   const openTextDocuments: Thenable<vscode.TextDocument>[] = [];
   files.forEach((file) => {
@@ -43,6 +47,7 @@ export async function getChangesForArbFiles(
       ),
       toJson(
         content.getText(),
+        files[index] === templateFile,
         key,
         description,
         value,

--- a/src/extension/sortArbFiles.ts
+++ b/src/extension/sortArbFiles.ts
@@ -13,7 +13,7 @@ export async function sortArbFiles(): Promise<vscode.WorkspaceEdit> {
   }
 
   const projectName = getProjectName(activeTextEditor.document.uri);
-  const files = await getArbFiles(projectName);
+  const files = (await getArbFiles(projectName))[0];
   if (files.length === 0) {
     const errorMessage = 'No arb files found.';
     vscode.window.showErrorMessage(errorMessage);

--- a/src/extension/toJson.ts
+++ b/src/extension/toJson.ts
@@ -82,6 +82,7 @@ const replacePlaceholders = (
 
 export function toJson(
   text: string,
+  isTemplateFile: boolean,
   key: string,
   description: string | null,
   value: string,
@@ -96,7 +97,7 @@ export function toJson(
     placeholders.length > 0 ? replacePlaceholders(value, placeholders) : value
   );
 
-  if (description || placeholders.length > 0) {
+  if (isTemplateFile && (description || placeholders.length > 0)) {
     const entry = {
       ...(description && { description }),
       ...(placeholders.length > 0 && {

--- a/src/test/suite/toJson.spec.ts
+++ b/src/test/suite/toJson.spec.ts
@@ -10,21 +10,24 @@ const defaultArbJson = `{
 
 describe('toJson', () => {
   it('should return json when simple messages', () => {
-    expect(toJson(defaultArbJson, 'helloWorld', null, 'Hello World', [], false))
-      .to.be.equal(`{
+    expect(
+      toJson(defaultArbJson, true, 'helloWorld', null, 'Hello World', [], false)
+    ).to.be.equal(`{
   "@@locale": "fr",
   "helloWorld": "Hello World"
 }`);
   });
 
-  it('should return json when message with description', () => {
+  it('should return json when message with description for template file', () => {
     expect(
       toJson(
         defaultArbJson,
+        true,
         'helloWorld',
         'Hello World Description',
         'Hello World',
         [],
+
         false
       )
     ).to.be.equal(`{
@@ -40,10 +43,12 @@ describe('toJson', () => {
     expect(
       toJson(
         defaultArbJson,
+        true,
         'hello',
         null,
         'Hello $name',
         [new Placeholder('name', 'name', PlaceholderType.String)],
+
         false
       )
     ).to.be.equal(`{
@@ -63,6 +68,7 @@ describe('toJson', () => {
     expect(
       toJson(
         defaultArbJson,
+        true,
         'hello',
         'Hello by name',
         'Hello $name',
@@ -87,6 +93,7 @@ describe('toJson', () => {
     expect(
       toJson(
         defaultArbJson,
+        true,
         'hello',
         null,
         'Hello $name $otherName',
@@ -116,6 +123,7 @@ describe('toJson', () => {
     expect(
       toJson(
         defaultArbJson,
+        true,
         'aNameOthernameContextOwnerTostring',
         null,
         'a $name $otherName ${context.owner.toString()}',
@@ -153,6 +161,7 @@ describe('toJson', () => {
     expect(
       toJson(
         defaultArbJson,
+        true,
         'hello',
         null,
         'Hello $name',
@@ -176,6 +185,7 @@ describe('toJson', () => {
     expect(
       toJson(
         defaultArbJson,
+        true,
         'hello',
         null,
         'Hello $name',
@@ -204,6 +214,7 @@ describe('toJson', () => {
     expect(
       toJson(
         defaultArbJson,
+        true,
         'hello',
         null,
         'Hello $name',
@@ -239,6 +250,7 @@ describe('toJson', () => {
     expect(
       toJson(
         defaultArbJson,
+        true,
         'hello',
         null,
         'Hello $name',
@@ -274,6 +286,7 @@ describe('toJson', () => {
     expect(
       toJson(
         defaultArbJson,
+        true,
         'hello',
         null,
         'Hello $name',
@@ -309,6 +322,7 @@ describe('toJson', () => {
     expect(
       toJson(
         defaultArbJson,
+        true,
         'hello',
         null,
         'Hello $name',
@@ -337,6 +351,7 @@ describe('toJson', () => {
     expect(
       toJson(
         defaultArbJson,
+        true,
         'hello',
         null,
         'Hello $name',
@@ -376,6 +391,7 @@ describe('toJson', () => {
   },
   "z": "Z {name}"
 }`,
+        true,
         'a',
         null,
         'A $name',
@@ -407,6 +423,7 @@ describe('toJson', () => {
     expect(
       toJson(
         defaultArbJson,
+        true,
         'countMessage',
         null,
         'You have $count photos',
@@ -428,6 +445,7 @@ describe('toJson', () => {
     expect(
       toJson(
         defaultArbJson,
+        true,
         'countMessage',
         null,
         'You have $otherCount photos',
@@ -442,6 +460,40 @@ describe('toJson', () => {
       "otherCount": {}
     }
   }
+}`);
+  });
+
+  it('should return json when message with description non template file', () => {
+    expect(
+      toJson(
+        defaultArbJson,
+        false,
+        'helloWorld',
+        'Hello World Description',
+        'Hello World',
+        [],
+        false
+      )
+    ).to.be.equal(`{
+  "@@locale": "fr",
+  "helloWorld": "Hello World"
+}`);
+  });
+
+  it('should return json when message with 1 placeholder for non template file', () => {
+    expect(
+      toJson(
+        defaultArbJson,
+        false,
+        'hello',
+        null,
+        'Hello $name',
+        [new Placeholder('name', 'name', PlaceholderType.String)],
+        false
+      )
+    ).to.be.equal(`{
+  "@@locale": "fr",
+  "hello": "Hello {name}"
 }`);
   });
 });


### PR DESCRIPTION
Resolves #227 

FYI I wasn't able to run the tests because of some weird error
```
[vscode.php]: One or more snippets from the extension 'php' very likely confuse snippet-variables and snippet-placeholders (see https://code.visualstudio.com/docs/editor/userdefinedsnippets#_snippet-syntax for more details)
Unexpected token '}', "}^��qV6$"... is not valid JSON
Error: Cannot find module '/home/robert/Documents/l10nization/out/test/suite/index'
```