### PR TITLE
Fix generation not running on already formatted file

### DIFF
--- a/src/extension/sortAndFormat.ts
+++ b/src/extension/sortAndFormat.ts
@@ -15,7 +15,6 @@ export async function sortAndFormat(document: vscode.TextDocument, editor: vscod
 
   if (text !== result && editor.document.version === version) {
     await editor.edit((edit) => edit.replace(replaceRange, result));
-
-    await runGeneration();
   }
+  await runGeneration();
 }


### PR DESCRIPTION
In my previous change I added to run everything when manually editing. I realized a bug where the generation did not run when file was edited but already formatted correctly. It would not jump into that if case and run the generation